### PR TITLE
Retrieve messages from channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Running the `slack_scrapper.py` script with the command `python slack_scrapper.p
   - Saves the list of channels on OPEN-Andela to a `channels.txt` file.
   - Save user details to a `user.txt` file.
   - Post a message to the `api_test` channel.
+  - Retrieve all message from the default channel(#api_test) or pass the channel ID as an argument. e.g `python slack_scrapper.py C3662H51`
 
 ## Contributors
 - **Rotimi Babalola**
 - **Olajide Bolaji 'Nuel**
+- **Inumidun Amao**

--- a/slack_scrapper.py
+++ b/slack_scrapper.py
@@ -1,4 +1,6 @@
 import os
+import requests
+import sys
 from os.path import join, dirname
 
 from dotenv import load_dotenv
@@ -6,11 +8,21 @@ from slackclient import SlackClient
 
 dotenv_path = join(dirname(__file__), '.env')
 load_dotenv(dotenv_path)
-
+ 
 # Get the slack token from the .env file
 token = os.environ.get("SLACK_TOKEN")
 
 sc = SlackClient(token)
+
+#Get all messages in a channel
+def allMessages(channel = 'C5GRK45A9'):
+    msg_endpoint = 'https://slack.com/api/channels.history?token=%s&channel=%s&pretty=1' % (token, channel)
+    all_messages = requests.get(msg_endpoint)
+    text_all_message = all_messages.text
+    with open("messages.json", "w") as message_file:
+        message_file.write(text_all_message);
+        message_file.close()
+    return all_messages.json()    
 
 # Get all channels in the Team
 channels = sc.api_call("channels.list")['channels']
@@ -48,6 +60,8 @@ with open("users.txt", "w") as textfile:
         # textfile.write("E-mail: {} \n".format(user["profile"]["email"]))
         textfile.write("ID: {} \n".format(user["id"]))
         textfile.write("------------------------------------------------ \n")
+
+allMessages(sys.args[1])
 
 # Post a message on the api_test channel
 message = input(


### PR DESCRIPTION
### What does this PR do?
This PR adds functionality to retrieve all messages from a channel

### Description of task to be completed
- First makes a get request to the channel.history slack api method, it then parses it as a text and writes it into the messages.json file. Afterwards, it returns the json format of the fetched request.
- By default, the channel it will fetch messages from is the #api_test channel, but if a channel was specified at the command line it fill fetch messages for that channel instead.

### How can this be manually tested?
just run for default `python slack_scrapper.py`
or run `python slack_scrapper.py <channel_id>`
